### PR TITLE
Update User-Agents to match Moip's new standard

### DIFF
--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -44,7 +44,7 @@ public class Client {
 
             USER_AGENT = properties.getProperty("userAgent");
         } catch (Exception e) {
-            USER_AGENT = "MoipJavaSDK/UnknownVersion";
+            USER_AGENT = "MoipJavaSDK/UnknownVersion (+https://github.com/moip/moip-sdk-java/)";
         }
     }
 

--- a/src/main/resources/moipJavaSDK.properties
+++ b/src/main/resources/moipJavaSDK.properties
@@ -1,1 +1,1 @@
-userAgent=MoipJavaSDK/${version}
+userAgent=MoipJavaSDK/${version} (+https://github.com/moip/moip-sdk-java/)


### PR DESCRIPTION
This PR updates the default User Agent header to match the new standard for Moip's SDKs (`Moip#{lang}SDK/#{version} (#{github_uri})`).