### PR TITLE
feat(transfer): adds create and revert a transfer

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,14 @@
     - [Consulta](#consulta-8)
     - [Exclusão](#exclusão-1)
     - [Atualização](#atualização)
-    - [Listagem](#listagem-1)  
+    - [Listagem](#listagem-1)
+  - [Transferência](#transferência)
+    - [Criação](#criação-8)
+      -[Conta Bancária](#conta-bancária)
+      -[Conta Moip](#conta-moip-1)
+    - [Consulta](#consulta-9)
+    - [Listagem](#listagem-2)
+    - [Reversão](#reversão)
   - [Custódia](#custódia)
     - [Pagamento com custódia](#pagamento-com-custódia)
     - [Liberação de custódia](#liberação-de-custódia)
@@ -687,8 +694,8 @@ List<BankAccount> createdBankAccounts = api.getList("MPA-E0BAC6D15696");
 ```
 
 ## Transferência
-### Criar transferência
-#### Por conta bancária
+### Criação
+#### Conta Bancária
 ```java
 Transfer transfer = api.transfer().create(new TransferRequest()
     .amount(1000)
@@ -711,7 +718,7 @@ Transfer transfer = api.transfer().create(new TransferRequest()
 ```
 
 
-#### Por conta Moip
+#### Conta Moip
 ```java
 Transfer transfer = api.transfer().create(new TransferRequest()
     .amount(1000)
@@ -721,21 +728,21 @@ Transfer transfer = api.transfer().create(new TransferRequest()
 );
 ```
 
-### Consultar transferência
+### Consulta
 ```java
 Transfer createdTransfer = api.transfer().get("TRA-28HRLYNLMUFH");
 
 System.out.println(createdTransfer);
 ```
 
-### Listar transferências
+### Listagem
 ```java
 TransferListResponse transferListResponse = api.transfer().list();
 
 System.out.println(transferListResponse);
 ```
 
-### Reverter transferência
+### Reversão
 ```java
 Transfer revertTransfer = api.transfer().reverse("TRA-B0W5FD5FCADG");
 ```

--- a/README.md
+++ b/README.md
@@ -688,9 +688,10 @@ List<BankAccount> createdBankAccounts = api.getList("MPA-E0BAC6D15696");
 
 ## Transferência
 ### Criar transferência
+#### Por conta bancária
 ```java
-TransferRequest transfer = new TransferRequest()
-    .amount(500)
+Transfer transfer = api.transfer().create(new TransferRequest()
+    .amount(1000)
     .transferInstrument(new TransferInstrumentRequest()
         .bankAccount(new BankAccountRequest()
             .bankNumber("001")
@@ -703,27 +704,40 @@ TransferRequest transfer = new TransferRequest()
                 .fullname("Nome do Portador")
                 .taxDocument(TaxDocumentRequest.cpf("22222222222"))
             )
+
         )
-    );
+    )
+);
+```
+
+
+#### Por conta Moip
+```java
+Transfer transfer = api.transfer().create(new TransferRequest()
+    .amount(1000)
+    .transferInstrument(new TransferInstrumentRequest()
+        .moipAccount(new MoipAccountRequest("MPA-5D5053C0B4A4"))
+    )
+);
 ```
 
 ### Consultar transferência
 ```java
-Transfer createdTransfer = api.get("TRA-28HRLYNLMUFH");
+Transfer createdTransfer = api.transfer().get("TRA-28HRLYNLMUFH");
 
 System.out.println(createdTransfer);
 ```
 
 ### Listar transferências
 ```java
-TransferListResponse transferListResponse = api.list();
+TransferListResponse transferListResponse = api.transfer().list();
 
 System.out.println(transferListResponse);
 ```
 
 ### Reverter transferência
 ```java
-Transfer revertTransfer = api.reverse("TRA-B0W5FD5FCADG");
+Transfer revertTransfer = api.transfer().reverse("TRA-B0W5FD5FCADG");
 ```
 
 ## Custódia

--- a/README.md
+++ b/README.md
@@ -686,6 +686,41 @@ BankAccount createdBankAccount = api.update("BKA-E0BAC6D15696",
 List<BankAccount> createdBankAccounts = api.getList("MPA-E0BAC6D15696");
 ```
 
+## Transferência
+### Criar transferência
+```java
+TransferRequest transfer = new TransferRequest()
+    .amount(500)
+    .transferInstrument(new TransferInstrumentRequest()
+        .bankAccount(new BankAccountRequest()
+            .bankNumber("001")
+            .agencyNumber("1111")
+            .agencyCheckNumber("2")
+            .accountNumber("9999")
+            .accountCheckNumber("8")
+            .checking()
+            .holder(new HolderRequest()
+                .fullname("Nome do Portador")
+                .taxDocument(TaxDocumentRequest.cpf("22222222222"))
+            )
+        )
+    );
+```
+
+### Consultar transferência
+```java
+Transfer createdTransfer = api.get("TRA-28HRLYNLMUFH");
+
+System.out.println(createdTransfer);
+```
+
+### Listar transferências
+```java
+TransferListResponse transferListResponse = api.list();
+
+System.out.println(transferListResponse);
+```
+
 ## Custódia
 ### Pagamento com custódia
 ```java

--- a/README.md
+++ b/README.md
@@ -721,6 +721,11 @@ TransferListResponse transferListResponse = api.list();
 System.out.println(transferListResponse);
 ```
 
+### Reverter transferência
+```java
+Transfer revertTransfer = api.reverse("TRA-B0W5FD5FCADG");
+```
+
 ## Custódia
 ### Pagamento com custódia
 ```java

--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -73,6 +73,10 @@ public class Client {
         return doRequest("POST", path, object, type, contentType);
     }
 
+    public <T> T post(final String path, final Class<T> type) {
+        return doRequest("POST", path, null, type, ContentType.APPLICATION_JSON);
+    }
+
     public <T> T put(final String path, final Object object, final Class<T> type) {
         return doRequest("PUT", path, object, type, ContentType.APPLICATION_JSON);
     }

--- a/src/main/java/br/com/moip/api/TransferApi.java
+++ b/src/main/java/br/com/moip/api/TransferApi.java
@@ -2,6 +2,7 @@ package br.com.moip.api;
 
 import br.com.moip.Client;
 import br.com.moip.api.filter.Pagination;
+import br.com.moip.request.TransferRequest;
 import br.com.moip.resource.Transfer;
 import br.com.moip.response.TransferListResponse;
 
@@ -13,6 +14,8 @@ public class TransferApi {
     public TransferApi(final Client client) {
         this.client = client;
     }
+
+    public Transfer create(final TransferRequest transfer){ return client.post(TRANSFER_URL, transfer, Transfer.class); }
 
     public Transfer get(final String id) {
         return client.get(TRANSFER_URL + "/" + id, Transfer.class);

--- a/src/main/java/br/com/moip/api/TransferApi.java
+++ b/src/main/java/br/com/moip/api/TransferApi.java
@@ -17,7 +17,7 @@ public class TransferApi {
 
     public Transfer create(final TransferRequest transfer) { return client.post(TRANSFER_URL, transfer, Transfer.class); }
 
-    public Transfer reverse(final String id) { return client.post(TRANSFER_URL + "/" + id + "/" + "reverse", Transfer.class); }
+    public Transfer reverse(final String id) { return client.post(TRANSFER_URL + "/" + id + "/reverse", Transfer.class); }
 
     public Transfer get(final String id) {
         return client.get(TRANSFER_URL + "/" + id, Transfer.class);

--- a/src/main/java/br/com/moip/api/TransferApi.java
+++ b/src/main/java/br/com/moip/api/TransferApi.java
@@ -15,7 +15,9 @@ public class TransferApi {
         this.client = client;
     }
 
-    public Transfer create(final TransferRequest transfer){ return client.post(TRANSFER_URL, transfer, Transfer.class); }
+    public Transfer create(final TransferRequest transfer) { return client.post(TRANSFER_URL, transfer, Transfer.class); }
+
+    public Transfer reverse(final String id) { return client.post(TRANSFER_URL + "/" + id + "/" + "reverse", Transfer.class); }
 
     public Transfer get(final String id) {
         return client.get(TRANSFER_URL + "/" + id, Transfer.class);

--- a/src/main/java/br/com/moip/request/MoipAccountRequest.java
+++ b/src/main/java/br/com/moip/request/MoipAccountRequest.java
@@ -1,0 +1,14 @@
+package br.com.moip.request;
+
+public class MoipAccountRequest {
+
+    private final String id;
+
+    public MoipAccountRequest(String moipAccount) {
+        this.id = moipAccount;
+    }
+
+    public String getId() {
+        return id;
+    }
+}

--- a/src/main/java/br/com/moip/request/ReceiverRequest.java
+++ b/src/main/java/br/com/moip/request/ReceiverRequest.java
@@ -53,15 +53,3 @@ public class ReceiverRequest {
         return feePayor;
     }
 }
-
-class MoipAccountRequest {
-    private final String id;
-
-    public MoipAccountRequest(String moipAccount) {
-        this.id = moipAccount;
-    }
-
-    public String getId() {
-        return id;
-    }
-}

--- a/src/main/java/br/com/moip/request/TaxDocumentRequest.java
+++ b/src/main/java/br/com/moip/request/TaxDocumentRequest.java
@@ -42,10 +42,11 @@ public class TaxDocumentRequest {
 
     @Override
     public String toString() {
-        return "TaxDocument{" +
-                "type='" + type + '\'' +
-                ", number='" + number + '\'' +
-                '}';
+        final StringBuilder sb = new StringBuilder("TaxDocument{");
+        sb.append("type=").append(type);
+        sb.append(", number='").append(number).append('\'');
+        sb.append('}');
+        return sb.toString();
     }
 
     private enum Type {

--- a/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
+++ b/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
@@ -1,21 +1,21 @@
 package br.com.moip.request;
 
-import br.com.moip.resource.BankAccount;
-
 public class TransferInstrumentRequest {
 
     private Method method;
     private BankAccountRequest bankAccount;
+    private MoipAccountRequest moipAccount;
 
-    public TransferInstrumentRequest bankAccount(BankAccountRequest bankAccount){
+    public TransferInstrumentRequest bankAccount(BankAccountRequest bankAccount) {
         this.method = Method.BANK_ACCOUNT;
         this.bankAccount = bankAccount;
 
         return this;
     }
 
-    public TransferInstrumentRequest moipAccount(){
+    public TransferInstrumentRequest moipAccount(MoipAccountRequest moipAccount) {
         this.method = Method.MOIP_ACCOUNT;
+        this.moipAccount = moipAccount;
 
         return this;
     }
@@ -26,9 +26,15 @@ public class TransferInstrumentRequest {
 
     @Override
     public String toString(){
-        return new StringBuilder("TransferInstrumentRequest{")
+        if(method == Method.BANK_ACCOUNT)
+                return new StringBuilder("TransferInstrumentRequest{")
+                        .append("method=").append(method)
+                        .append(", bankAccount=").append(bankAccount)
+                        .append("}").toString();
+
+        else return  new StringBuilder("TransferInstrumentRequest{")
                 .append("method=").append(method)
-                .append(", bankAccount=").append(bankAccount)
+                .append(", moipAccount=").append(moipAccount)
                 .append("}").toString();
     }
 }

--- a/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
+++ b/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
@@ -1,0 +1,34 @@
+package br.com.moip.request;
+
+import br.com.moip.resource.BankAccount;
+
+public class TransferInstrumentRequest {
+
+    private Method method;
+    private BankAccountRequest bankAccount;
+
+    public TransferInstrumentRequest bankAccount(BankAccountRequest bankAccount){
+        this.method = Method.BANK_ACCOUNT;
+        this.bankAccount = bankAccount;
+
+        return this;
+    }
+
+    public TransferInstrumentRequest moipAccount(){
+        this.method = Method.MOIP_ACCOUNT;
+
+        return this;
+    }
+
+    public enum Method{
+        BANK_ACCOUNT, MOIP_ACCOUNT;
+    }
+
+    @Override
+    public String toString(){
+        return new StringBuilder("TransferInstrumentRequest{")
+                .append("method=").append(method)
+                .append(", bankAccount=").append(bankAccount)
+                .append("}").toString();
+    }
+}

--- a/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
+++ b/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
@@ -26,15 +26,15 @@ public class TransferInstrumentRequest {
 
     @Override
     public String toString(){
+        StringBuilder stringBuilder = new StringBuilder("TransferInstrumentRequest{")
+            .append("method=").append(method);
         if(method == Method.BANK_ACCOUNT)
-                return new StringBuilder("TransferInstrumentRequest{")
-                        .append("method=").append(method)
-                        .append(", bankAccount=").append(bankAccount)
-                        .append("}").toString();
+            stringBuilder.append(", bankAccount=").append(bankAccount);
 
-        else return  new StringBuilder("TransferInstrumentRequest{")
-                .append("method=").append(method)
-                .append(", moipAccount=").append(moipAccount)
-                .append("}").toString();
+        else
+            stringBuilder.append(", moipAccount=").append(moipAccount);
+        stringBuilder.append("}");
+
+        return stringBuilder.toString();
     }
 }

--- a/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
+++ b/src/main/java/br/com/moip/request/TransferInstrumentRequest.java
@@ -25,16 +25,12 @@ public class TransferInstrumentRequest {
     }
 
     @Override
-    public String toString(){
-        StringBuilder stringBuilder = new StringBuilder("TransferInstrumentRequest{")
-            .append("method=").append(method);
-        if(method == Method.BANK_ACCOUNT)
-            stringBuilder.append(", bankAccount=").append(bankAccount);
-
-        else
-            stringBuilder.append(", moipAccount=").append(moipAccount);
-        stringBuilder.append("}");
-
-        return stringBuilder.toString();
+    public String toString() {
+        final StringBuilder sb = new StringBuilder("TransferInstrument{");
+        sb.append("method=").append(method);
+        sb.append(", bankAccount=").append(bankAccount);
+        sb.append(", moipAccount=").append(moipAccount);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/br/com/moip/request/TransferRequest.java
+++ b/src/main/java/br/com/moip/request/TransferRequest.java
@@ -1,0 +1,31 @@
+package br.com.moip.request;
+
+public class TransferRequest {
+
+    private Integer amount;
+    private TransferInstrumentRequest transferInstrument;
+
+    public TransferRequest amount(Integer amount){
+        this.amount = amount;
+
+        return this;
+    }
+
+    public Integer getAmount() { return amount; }
+
+    public TransferRequest transferInstrument(TransferInstrumentRequest transferInstrument){
+        this.transferInstrument = transferInstrument;
+
+        return this;
+    }
+
+    public TransferInstrumentRequest getTransferInstrument() { return transferInstrument; }
+
+    @Override
+    public String toString(){
+        return new StringBuilder("TransferRequest{")
+                .append("amount=").append(amount)
+                .append(", transferInstrument=").append(transferInstrument)
+                .append("}").toString();
+    }
+}

--- a/src/main/java/br/com/moip/resource/Holder.java
+++ b/src/main/java/br/com/moip/resource/Holder.java
@@ -46,4 +46,14 @@ public class Holder {
 
         return this;
     }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("Holder{")
+                .append("fullname=").append(fullname)
+                .append(", birthdate=").append(birthdate)
+                .append(", phone=").append(phone)
+                .append(", taxDocument").append(taxDocument)
+                .append("}").toString();
+    }
 }

--- a/src/main/java/br/com/moip/resource/MoipAccount.java
+++ b/src/main/java/br/com/moip/resource/MoipAccount.java
@@ -43,7 +43,7 @@ public class MoipAccount {
     public String toString() {
         return new StringBuilder("MoipAccount{")
                 .append("id='").append(id).append('\'')
-                .append("email='").append(email).append('\'')
+                .append(", email='").append(email).append('\'')
                 .append(", fullname='").append(fullname).append('\'')
                 .append(", login='").append(login).append('\'')
                 .append('}').toString();

--- a/src/main/java/br/com/moip/resource/ReverseTransfer.java
+++ b/src/main/java/br/com/moip/resource/ReverseTransfer.java
@@ -1,0 +1,58 @@
+package br.com.moip.resource;
+
+import br.com.moip.resource.links.TransferLinks;
+
+import java.util.Date;
+
+public class ReverseTransfer {
+
+    private int fee;
+    private int amount;
+    private String id;
+    private TransferInstrument transferInstrument;
+    private TransferStatus status;
+    private Date createdAt;
+    private TransferLinks _links;
+
+    public int getFee() { return fee; }
+
+    public void setFee(int fee) { this.fee = fee; }
+
+    public int getAmount() { return amount; }
+
+    public void setAmount(int amount) { this.amount = amount; }
+
+    public String getId() { return id; }
+
+    public void setId(String id) { this.id = id; }
+
+    public TransferInstrument getTransferInstrument() { return transferInstrument; }
+
+    public void setTransferInstrument(TransferInstrument transferInstrument) { this.transferInstrument = transferInstrument; }
+
+    public TransferStatus getStatus() { return status; }
+
+    public void setStatus(TransferStatus status) { this.status = status; }
+
+    public Date getCreatedAt() { return createdAt; }
+
+    public void setCreatedAt(Date createdAt) { this.createdAt = createdAt; }
+
+    public TransferLinks getLinks(){ return _links; }
+
+    public void setLinks(TransferLinks _links) { this._links = _links; }
+
+    @Override
+    public String toString() {
+
+        return new StringBuilder("Transfer{")
+                .append("fee=").append(fee)
+                .append(", amount=").append(amount)
+                .append(", id=").append(id)
+                .append(", transferInstrument=").append(transferInstrument)
+                .append(", status=").append(status)
+                .append(", createdAt=").append(createdAt)
+                .append(", _links=").append(_links)
+                .append("}").toString();
+    }
+}

--- a/src/main/java/br/com/moip/resource/Transfer.java
+++ b/src/main/java/br/com/moip/resource/Transfer.java
@@ -90,28 +90,17 @@ public class Transfer {
 
     @Override
     public String toString() {
-        if(status == TransferStatus.REVERSED)
-            return new StringBuilder("Transfer{")
-                    .append("id=").append(id)
-                    .append(", amount=").append(amount)
-                    .append(", fee=").append(fee)
-                    .append(", status=").append(status)
-                    .append(", createdAt=").append(createdAt)
-                    .append(", updatedAt=").append(updatedAt)
-                    .append(", transferInstrument=").append(transferInstrument)
-                    .append(", _links=").append(_links)
-                    .append('}').toString();
-
-        return new StringBuilder("Transfer{")
-                .append("id=").append(id)
-                .append(", amount=").append(amount)
-                .append(", fee=").append(fee)
-                .append(", status=").append(status)
-                .append(", createdAt=").append(createdAt)
-                .append(", updatedAt=").append(updatedAt)
-                .append(", transferInstrument=").append(transferInstrument)
-                .append(", _links=Links{self=Href{href=").append(_links.getSelf())
-                .append("}").append("}")
-                .append("}").toString();
+        final StringBuilder sb = new StringBuilder("Transfer{");
+        sb.append("id='").append(id).append('\'');
+        sb.append(", amount=").append(amount);
+        sb.append(", fee=").append(fee);
+        sb.append(", status=").append(status);
+        sb.append(", createdAt=").append(createdAt);
+        sb.append(", updatedAt=").append(updatedAt);
+        sb.append(", role=").append(role);
+        sb.append(", transferInstrument=").append(transferInstrument);
+        sb.append(", _links=").append(_links);
+        sb.append('}');
+        return sb.toString();
     }
 }

--- a/src/main/java/br/com/moip/resource/Transfer.java
+++ b/src/main/java/br/com/moip/resource/Transfer.java
@@ -1,5 +1,7 @@
 package br.com.moip.resource;
 
+import br.com.moip.resource.links.TransferLinks;
+
 import java.util.Date;
 
 public class Transfer {
@@ -12,6 +14,7 @@ public class Transfer {
     private Date updatedAt;
     private Role role;
     private TransferInstrument transferInstrument;
+    private TransferLinks _links;
 
     public String getId() {
         return id;
@@ -82,6 +85,9 @@ public class Transfer {
         PAYER
     }
 
+    public TransferLinks getLinks() { return _links; }
+    public void setLinks(TransferLinks _links) { this._links = _links; }
+
     @Override
     public String toString() {
 
@@ -93,6 +99,7 @@ public class Transfer {
                 .append(", createdAt=").append(createdAt)
                 .append(", updatedAt=").append(updatedAt)
                 .append(", transferInstrument=").append(transferInstrument)
+                .append(", _links=").append(_links)
                 .append('}').toString();
     }
 }

--- a/src/main/java/br/com/moip/resource/Transfer.java
+++ b/src/main/java/br/com/moip/resource/Transfer.java
@@ -90,6 +90,17 @@ public class Transfer {
 
     @Override
     public String toString() {
+        if(status == TransferStatus.REVERSED)
+            return new StringBuilder("Transfer{")
+                    .append("id=").append(id)
+                    .append(", amount=").append(amount)
+                    .append(", fee=").append(fee)
+                    .append(", status=").append(status)
+                    .append(", createdAt=").append(createdAt)
+                    .append(", updatedAt=").append(updatedAt)
+                    .append(", transferInstrument=").append(transferInstrument)
+                    .append(", _links=").append(_links)
+                    .append('}').toString();
 
         return new StringBuilder("Transfer{")
                 .append("id=").append(id)
@@ -99,7 +110,8 @@ public class Transfer {
                 .append(", createdAt=").append(createdAt)
                 .append(", updatedAt=").append(updatedAt)
                 .append(", transferInstrument=").append(transferInstrument)
-                .append(", _links=").append(_links)
-                .append('}').toString();
+                .append(", _links=Links{self=Href{href=").append(_links.getSelf())
+                .append("}").append("}")
+                .append("}").toString();
     }
 }

--- a/src/main/java/br/com/moip/resource/links/TransferLinks.java
+++ b/src/main/java/br/com/moip/resource/links/TransferLinks.java
@@ -1,0 +1,15 @@
+package br.com.moip.resource.links;
+
+public class TransferLinks {
+
+    private Href self;
+
+    public String getSelf() { return self.getHref(); }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("Links{")
+        .append("self=").append(self)
+        .append('}').toString();
+    }
+}

--- a/src/main/java/br/com/moip/resource/links/TransferLinks.java
+++ b/src/main/java/br/com/moip/resource/links/TransferLinks.java
@@ -3,13 +3,17 @@ package br.com.moip.resource.links;
 public class TransferLinks {
 
     private Href self;
+    private Href reverse;
 
     public String getSelf() { return self.getHref(); }
+
+    public String getReverse() { return reverse.getHref(); }
 
     @Override
     public String toString() {
         return new StringBuilder("Links{")
-        .append("self=").append(self)
+        .append("reverse=").append(reverse)
+        .append(", self=").append(self)
         .append('}').toString();
     }
 }

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -2,7 +2,6 @@ package br.com.moip.api;
 
 import br.com.moip.Client;
 import br.com.moip.request.TransferRequest;
-import br.com.moip.request.TransferRequestTest;
 import br.com.moip.resource.*;
 import br.com.moip.response.TransferListResponse;
 import com.rodrigosaito.mockwebserver.player.Play;
@@ -10,9 +9,7 @@ import com.rodrigosaito.mockwebserver.player.Player;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import sun.net.ftp.FtpClient;
 
-import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class TransferApiTest {

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -1,17 +1,18 @@
 package br.com.moip.api;
 
 import br.com.moip.Client;
-import br.com.moip.exception.UnexpectedException;
 import br.com.moip.exception.ValidationException;
-import br.com.moip.request.*;
-
+import br.com.moip.request.TaxDocumentRequest;
+import br.com.moip.request.BankAccountRequest;
+import br.com.moip.request.HolderRequest;
+import br.com.moip.request.TransferInstrumentRequest;
+import br.com.moip.request.TransferRequest;
 import br.com.moip.resource.Transfer;
 import br.com.moip.resource.TransferInstrument;
 import br.com.moip.resource.TransferStatus;
 import br.com.moip.response.TransferListResponse;
 import com.rodrigosaito.mockwebserver.player.Play;
 import com.rodrigosaito.mockwebserver.player.Player;
-import javassist.tools.web.BadHttpRequest;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -1,15 +1,18 @@
 package br.com.moip.api;
 
 import br.com.moip.Client;
-import br.com.moip.resource.Transfer;
-import br.com.moip.resource.TransferStatus;
+import br.com.moip.request.TransferRequest;
+import br.com.moip.request.TransferRequestTest;
+import br.com.moip.resource.*;
 import br.com.moip.response.TransferListResponse;
 import com.rodrigosaito.mockwebserver.player.Play;
 import com.rodrigosaito.mockwebserver.player.Player;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import sun.net.ftp.FtpClient;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
 public class TransferApiTest {
@@ -20,11 +23,35 @@ public class TransferApiTest {
 
     @Rule
     public Player player = new Player();
+    private TransferRequest transferRequest;
 
     @Before
     public void setUp() {
         Client client = clientFactory.client(player.getURL("").toString());
         api = new TransferApi(client);
+        transferRequest = new TransferRequest();
+    }
+
+    @Play("transfers/create")
+    @Test
+    public void shouldCreateATransfer(){
+        Transfer transfer = api.create(transferRequest);
+
+        assertEquals("TRA-28HRLYNLMUFH", transfer.getId());
+        assertEquals(500, transfer.getAmount());
+        assertEquals(TransferInstrument.Method.BANK_ACCOUNT, transfer.getTransferInstrument().getMethod());
+        assertEquals("BKA-I268MOXX85BF", transfer.getTransferInstrument().getBankAccount().getId());
+        assertEquals("1111", transfer.getTransferInstrument().getBankAccount().getAgencyNumber());
+        assertEquals("033.575.852-51", transfer.getTransferInstrument().getBankAccount().getHolder().getTaxDocument().getNumber());
+        assertEquals("Integração Taxa por canal", transfer.getTransferInstrument().getBankAccount().getHolder().getFullname());
+        assertEquals("9999", transfer.getTransferInstrument().getBankAccount().getAccountNumber());
+        assertEquals("8", transfer.getTransferInstrument().getBankAccount().getAccountCheckNumber());
+        assertEquals("2", transfer.getTransferInstrument().getBankAccount().getAgencyCheckNumber());
+        assertEquals("BANCO DO BRASIL S.A.", transfer.getTransferInstrument().getBankAccount().getBankName());
+        assertEquals("001", transfer.getTransferInstrument().getBankAccount().getBankNumber());
+        assertEquals(TransferStatus.REQUESTED, transfer.getStatus());
+        assertEquals("https://sandbox.moip.com.br/v2/transfers/TRA-28HRLYNLMUFH", transfer.getLinks().getSelf());
+
     }
 
     @Play("transfers/get")

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -34,7 +34,7 @@ public class TransferApiTest {
 
     @Play("transfers/create")
     @Test
-    public void shouldCreateATransfer(){
+    public void shouldCreateATransfer() {
         Transfer transfer = api.create(transferRequest);
 
         assertEquals("TRA-28HRLYNLMUFH", transfer.getId());
@@ -76,5 +76,21 @@ public class TransferApiTest {
         assertEquals("TRA-BVVSKE5K26GG", transferListResponse.getTransfers().get(1).getId());
         assertEquals(TransferStatus.COMPLETED, transferListResponse.getTransfers().get(1).getStatus());
         assertEquals(Transfer.Role.RECEIVER, transferListResponse.getTransfers().get(1).getRole());
+    }
+
+    @Play("transfers/reverse")
+    @Test
+    public void shouldReverseATransfer() {
+        Transfer revertTransfer = api.reverse("TRA-B0W5FD5FCADG");
+        assertEquals(0, revertTransfer.getFee());
+        assertEquals(1000, revertTransfer.getAmount());
+        assertEquals("TRA-B0W5FD5FCADG", revertTransfer.getId());
+        assertEquals("MPA-AE2OAL41CBB1", revertTransfer.getTransferInstrument().getMoipAccount().getId());
+        assertEquals("iori@labs.moip.com.br", revertTransfer.getTransferInstrument().getMoipAccount().getLogin());
+        assertEquals("iori@labs.moip.com.br", revertTransfer.getTransferInstrument().getMoipAccount().getEmail());
+        assertEquals("Iori Yagami", revertTransfer.getTransferInstrument().getMoipAccount().getFullname());
+        assertEquals(TransferInstrument.Method.MOIP_ACCOUNT, revertTransfer.getTransferInstrument().getMethod());
+        assertEquals(TransferStatus.REVERSED, revertTransfer.getStatus());
+        assertEquals("https://sandbox.moip.com.br/v2/transfers/TRA-B0W5FD5FCADG", revertTransfer.getLinks().getSelf());
     }
 }

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -2,7 +2,10 @@ package br.com.moip.api;
 
 import br.com.moip.Client;
 import br.com.moip.request.TransferRequest;
-import br.com.moip.resource.*;
+
+import br.com.moip.resource.Transfer;
+import br.com.moip.resource.TransferInstrument;
+import br.com.moip.resource.TransferStatus;
 import br.com.moip.response.TransferListResponse;
 import com.rodrigosaito.mockwebserver.player.Play;
 import com.rodrigosaito.mockwebserver.player.Player;

--- a/src/test/java/br/com/moip/api/TransferApiTest.java
+++ b/src/test/java/br/com/moip/api/TransferApiTest.java
@@ -14,6 +14,7 @@ import org.junit.Rule;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 
 public class TransferApiTest {
 
@@ -51,7 +52,10 @@ public class TransferApiTest {
         assertEquals("001", transfer.getTransferInstrument().getBankAccount().getBankNumber());
         assertEquals(TransferStatus.REQUESTED, transfer.getStatus());
         assertEquals("https://sandbox.moip.com.br/v2/transfers/TRA-28HRLYNLMUFH", transfer.getLinks().getSelf());
-
+        assertNotEquals("TRA-28HRLYNLMUFI", transfer.getId());
+        assertNotEquals(5000, transfer.getAmount());
+        assertNotEquals("BKA-I268MOXX85BG", transfer.getTransferInstrument().getBankAccount().getId());
+        assertNotEquals("133.575.852-51", transfer.getTransferInstrument().getBankAccount().getHolder().getTaxDocument().getNumber());
     }
 
     @Play("transfers/get")

--- a/src/test/java/br/com/moip/request/TransferRequestTest.java
+++ b/src/test/java/br/com/moip/request/TransferRequestTest.java
@@ -1,0 +1,35 @@
+package br.com.moip.request;
+
+import br.com.moip.util.GsonFactory;
+import com.google.gson.JsonObject;
+import org.json.JSONException;
+import org.junit.Test;
+import org.skyscreamer.jsonassert.JSONAssert;
+
+public class TransferRequestTest extends RequestTest{
+
+    @Test
+    public void testCreateTransfer() throws JSONException{
+        TransferRequest transfer = new TransferRequest()
+            .amount(500)
+            .transferInstrument(new TransferInstrumentRequest()
+                .bankAccount(new BankAccountRequest()
+                    .bankNumber("001")
+                    .agencyNumber("1111")
+                    .agencyCheckNumber("2")
+                    .accountNumber("9999")
+                    .accountCheckNumber("8")
+                    .checking()
+                    .holder(new HolderRequest()
+                        .fullname("Nome do Portador")
+                        .taxDocument(TaxDocumentRequest.cpf("22222222222"))
+                        )
+                )
+            );
+
+        String json = new GsonFactory().gson().toJson(transfer);
+        JsonObject expectedJSON = getJsonFileAsJsonObject("transfer/create.json");
+
+        JSONAssert.assertEquals(expectedJSON.toString(), json, true);
+    }
+}

--- a/src/test/java/br/com/moip/request/TransferRequestTest.java
+++ b/src/test/java/br/com/moip/request/TransferRequestTest.java
@@ -9,7 +9,7 @@ import org.skyscreamer.jsonassert.JSONAssert;
 public class TransferRequestTest extends RequestTest{
 
     @Test
-    public void testCreateTransfer() throws JSONException{
+    public void testCreateTransfer() throws JSONException {
         TransferRequest transfer = new TransferRequest()
             .amount(500)
             .transferInstrument(new TransferInstrumentRequest()

--- a/src/test/resources/jsons/transfer/create.json
+++ b/src/test/resources/jsons/transfer/create.json
@@ -1,0 +1,1 @@
+{"amount":500,"transferInstrument":{"method":"BANK_ACCOUNT","bankAccount":{"type":"CHECKING","bankNumber":"001","agencyNumber":"1111","agencyCheckNumber":"2","accountNumber":"9999","accountCheckNumber":"8","holder":{"fullname":"Nome do Portador","taxDocument":{"type":"CPF","number":"22222222222"}}}}}

--- a/src/test/resources/plays/transfers/create.yaml
+++ b/src/test/resources/plays/transfers/create.yaml
@@ -1,0 +1,90 @@
+!play
+interactions:
+-
+  request:
+    uri: /v2/transfers
+    headers:
+      Content-Type: application/json
+      Authorization: Basic MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6QUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQg==
+    method: POST
+  response:
+    status: 201
+    headers:
+      "Content-Type": application/json
+    body: |
+      {
+         "updatedAt":"2015-10-01T17:24:25.160-03",
+         "fee":0,
+         "amount":500,
+         "id":"TRA-28HRLYNLMUFH",
+         "transferInstrument":{
+            "method":"BANK_ACCOUNT",
+            "bankAccount":{
+               "id":"BKA-I268MOXX85BF",
+               "agencyNumber":"1111",
+               "holder":{
+                  "taxDocument":{
+                     "number":"033.575.852-51",
+                     "type":"CPF"
+                  },
+                  "fullname":"Integração Taxa por canal"
+               },
+               "accountNumber":"9999",
+               "accountCheckNumber":"8",
+               "bankName":"BANCO DO BRASIL S.A.",
+               "type":"CHECKING",
+               "agencyCheckNumber":"2",
+               "bankNumber":"001"
+            }
+         },
+         "status":"REQUESTED",
+         "createdAt":"2015-10-01T17:24:25.160-03",
+         "events":[
+            {
+               "createdAt":"2015-10-01T17:24:25.000-03",
+               "description":"Requested",
+               "type":"TRANSFER.REQUESTED"
+            }
+         ],
+         "entries":[
+            {
+               "external_id":"ENT-X3CG3TR5DRW4",
+               "scheduledFor":"2015-10-01T17:24:25.000-03",
+               "status":"SETTLED",
+               "moipAccount":{
+                  "account":"MPA-UVJPXXO25KYX"
+               },
+               "fees":[
+                  {
+                     "amount":0,
+                     "type":"FIXED_FEE"
+                  }
+               ],
+               "type":"TRANSFER_TO_BANK_ACCOUNT",
+               "grossAmount":-500,
+               "moipAccountId":9125,
+               "updatedAt":"2015-10-01T17:24:25.835-03",
+               "id":197194,
+               "installment":{
+                  "amount":1,
+                  "number":1
+               },
+               "references":[
+                  {
+                     "value":"APP-GLQRIP429OK7",
+                     "type":"CHANNEL"
+                  }
+               ],
+               "eventId":"TRA-28HRLYNLMUFH",
+               "createdAt":"2015-10-01T17:24:25.775-03",
+               "description":"Transferencia para conta bancaria - Transferencia TRA-28HRLYNLMUFH",
+               "settledAt":"2015-10-01T17:24:25.835-03",
+               "liquidAmount":-500
+            }
+         ],
+         "_links":{
+            "self":{
+               "href":"https://sandbox.moip.com.br/v2/transfers/TRA-28HRLYNLMUFH"
+            }
+         }
+      }

--- a/src/test/resources/plays/transfers/reverse.yaml
+++ b/src/test/resources/plays/transfers/reverse.yaml
@@ -1,0 +1,35 @@
+!play
+interactions:
+-
+  request:
+    uri: /v2/transfers/TRA-B0W5FD5FCADG/reverse
+    headers:
+      Content-Type: application/json
+      Authorization: Basic MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6QUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQg==
+    method: POST
+  response:
+    status: 200
+    headers:
+      "Content-Type": application/json
+    body: |
+      {
+        "fee": 0,
+        "amount": 1000,
+        "id": "TRA-B0W5FD5FCADG",
+        "transferInstrument": {
+          "moipAccount": {
+            "id": "MPA-AE2OAL41CBB1",
+            "email": "iori@labs.moip.com.br",
+            "login": "iori@labs.moip.com.br",
+            "fullname": "Iori Yagami"
+          },
+          "method": "MOIP_ACCOUNT"
+        },
+        "status": "REVERSED",
+        "createdAt": "2015-10-15T16:18:41-0300",
+        "_links": {
+          "self": {
+            "href": "https://sandbox.moip.com.br/v2/transfers/TRA-B0W5FD5FCADG"
+          }
+        }
+      }

--- a/src/test/resources/plays/transfers/validation_exception.yaml
+++ b/src/test/resources/plays/transfers/validation_exception.yaml
@@ -1,0 +1,15 @@
+!play
+interactions:
+-
+  request:
+    uri: /v2/transfers
+    headers:
+      Content-Type: application/json
+      Authorization: Basic MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6QUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQg==
+    method: POST
+  response:
+    status: 404
+    headers:
+      "Content-Type": application/json
+    body: |
+      { "ERROR" : "Ops... You are trying to access an invalid URL" }


### PR DESCRIPTION
## Story
https://moippagamentos.atlassian.net/browse/DX-95
https://moippagamentos.atlassian.net/browse/DX-96

## Description
Adds create and revert a transfer features. Adds examples for all available transfers features.

## Tasks
- [x] add create a transfer feature
- [x] add tests to create a transfer (`TransferApiTest.java`)
- [x] add tests to create a transfer (`TransferRequestTest.java`)
- [x] document create a transfer example
- [x] document get transfer example
- [x] document list transfers example
- [x] add revert a transfer feature
- [x] add tests to revert a transfer (`TransferApiTest.java`)
- [ ] ~add tests to revert a transfer (`TransferRequestTest.java`)~ _that's not necessary_
- [x] document revert a transfer example

>**Observations**:
>* was necessary create another post method, at `Client.java`, to make the reverse transfer request;
>* the `MoipAccountRequest` class was removed from `ReceiverRequest.java` and added to `MoipAccountRequest.java` to be used in more files;
>* the `TransferInstrumentRequest.java` was created to be used at `TransferRequest.java`, in the creation of a transfer;
>* the `TransferRequest.java` was added to create a transfer;
>* was added a `toString()` method, at `Holder.java`, to fix the request response;
>* the `ReverseTransfer.java` resource was created to build the response and add the output methods;
>* the `TransferLinks.java` resource was created to catch the links that will be returned at the response;
>* some unnecessary imports was removed.