### PR TITLE
Add feature to get Moip Account's Balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,10 @@
     - [Exclusão](#exclusão-1)
     - [Atualização](#atualização)
     - [Listagem](#listagem-1)
-  - [Lançamento](#lançamento)
+  - [Saldo Moip](#saldo-moip)
     - [Consulta](#consulta-9)
+  - [Lançamento](#lançamento)
+    - [Consulta](#consulta-10)
     - [Listagem](#listagem-2)
       - [Sem filtros de busca](#sem-filtros-de-busca)
       - [Com filtros de busca](#com-filtros-de-busca)
@@ -74,7 +76,7 @@
     - [Criação](#criação-8)
       -[Conta Bancária](#conta-bancária)
       -[Conta Moip](#conta-moip-1)
-    - [Consulta](#consulta-10)
+    - [Consulta](#consulta-11)
     - [Listagem](#listagem-3)
     - [Reversão](#reversão)
   - [Custódia](#custódia)
@@ -707,6 +709,21 @@ BankAccount createdBankAccount = api.bankAccount().update("BKA-E0BAC6D15696",
 ```java
 List<BankAccount> createdBankAccounts = api.bankAccount().getList("MPA-E0BAC6D15696");
 ```
+
+## Saldo Moip
+O Saldo é a composição de valores atuais disponíveis, indisponíveis (bloqueados) e futuros de uma determinada **Conta Moip**.
+
+> Esta API está na versão 2.1, contendo o _header_ **Accept**, com o valor `application/json;version=2.1`.
+### Consulta
+```java
+Balances balances = api.get();
+```
+
+Para consultar um saldo específico (indisponível, futuro e disponível):
+
+* **indisponíveis** - `balances.getUnavailable();`
+* **futuros** - `balances.getFuture();`
+* **disponíveis** - `balances.getCurrent();`
 
 ## Lançamento
 O Lançamento é um crédito ou débito no extrato ou no saldo futuro da conta de um recebedor. Ele é gerado quando um pagamento é autorizado, um reembolso é realizado ou em qualquer outra situação em que ocorram movimentações de valores na conta Moip de um lojista.

--- a/src/main/java/br/com/moip/API.java
+++ b/src/main/java/br/com/moip/API.java
@@ -1,19 +1,6 @@
 package br.com.moip;
 
-import br.com.moip.api.AccountAPI;
-import br.com.moip.api.InvoiceAPI;
-import br.com.moip.api.OrderAPI;
-import br.com.moip.api.PaymentAPI;
-import br.com.moip.api.CustomerAPI;
-import br.com.moip.api.ConnectAPI;
-import br.com.moip.api.NotificationPreferencesAPI;
-import br.com.moip.api.RefundAPI;
-import br.com.moip.api.MultiorderAPI;
-import br.com.moip.api.MultipaymentAPI;
-import br.com.moip.api.BankAccountsAPI;
-import br.com.moip.api.EscrowAPI;
-import br.com.moip.api.TransferApi;
-import br.com.moip.api.EntryAPI;
+import br.com.moip.api.*;
 
 public class API {
 
@@ -80,4 +67,6 @@ public class API {
     }
 
     public EntryAPI entry() { return new EntryAPI(client); }
+
+    public BalancesAPI balance() { return new BalancesAPI(client); }
 }

--- a/src/main/java/br/com/moip/API.java
+++ b/src/main/java/br/com/moip/API.java
@@ -1,6 +1,21 @@
 package br.com.moip;
 
-import br.com.moip.api.*;
+
+import br.com.moip.api.AccountAPI;
+import br.com.moip.api.InvoiceAPI;
+import br.com.moip.api.OrderAPI;
+import br.com.moip.api.PaymentAPI;
+import br.com.moip.api.CustomerAPI;
+import br.com.moip.api.ConnectAPI;
+import br.com.moip.api.NotificationPreferencesAPI;
+import br.com.moip.api.RefundAPI;
+import br.com.moip.api.MultiorderAPI;
+import br.com.moip.api.MultipaymentAPI;
+import br.com.moip.api.BankAccountsAPI;
+import br.com.moip.api.EscrowAPI;
+import br.com.moip.api.TransferApi;
+import br.com.moip.api.EntryAPI;
+import br.com.moip.api.BalancesAPI;
 
 public class API {
 

--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -41,7 +41,6 @@ public class Client {
     public static final String CONNECT_PRODUCTION = "https://connect.moip.com.br";
     public static final String CONNECT_SANDBOX = "https://connect-sandbox.moip.com.br";
     private static String USER_AGENT;
-    private static final String ACCEPT = "application/json;version=";
 
     static {
         try {
@@ -65,35 +64,44 @@ public class Client {
         this.gson = GsonFactory.gson();
     }
 
+    private String accept() {
+        return "application/json";
+    }
+
+    public String accept(String version) {
+        String value = "application/json";
+        switch (version) {
+            case "2.1": return value + ";version=" + version;
+        }
+        return value;
+    }
+
     public <T> T post(final String path, final Class<T> type) {
-        return doRequest("POST", path, null, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("POST", path, null, type, ContentType.APPLICATION_JSON, accept());
     }
 
     public <T> T post(final String path, final Object object, final Class<T> type) {
-        return doRequest("POST", path, object, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("POST", path, object, type, ContentType.APPLICATION_JSON, accept());
     }
 
     public <T> T post(final String path, final Object object, final Class<T> type, ContentType contentType) {
-        return doRequest("POST", path, object, type, contentType, null);
+        return doRequest("POST", path, object, type, contentType, accept());
     }
 
     public <T> T put(final String path, final Object object, final Class<T> type) {
-        return doRequest("PUT", path, object, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("PUT", path, object, type, ContentType.APPLICATION_JSON, accept());
     }
 
     public <T> T get(String path, Class<T> type) {
-        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, accept());
     }
 
     public <T> T get(String path, Class<T> type, String version) {
-        switch (version) {
-            case "2.1": return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, ACCEPT + version);
-        }
-        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, accept(version));
     }
 
     public <T> T delete(String path, Class<T> type) {
-        return doRequest("DELETE", path, null, type, ContentType.APPLICATION_JSON, null);
+        return doRequest("DELETE", path, null, type, ContentType.APPLICATION_JSON, accept());
     }
 
     private <T> T doRequest(final String method, final String path, final Object object, final Class<T> type, final ContentType contentType, final String accept) {
@@ -103,7 +111,7 @@ public class Client {
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("User-Agent", USER_AGENT);
             conn.setRequestProperty("Content-type", contentType.getMimeType());
-            if(accept != null) conn.setRequestProperty("Accept", accept);
+            conn.setRequestProperty("Accept", accept);
 
             conn.setRequestMethod(method);
 

--- a/src/main/java/br/com/moip/Client.java
+++ b/src/main/java/br/com/moip/Client.java
@@ -41,6 +41,7 @@ public class Client {
     public static final String CONNECT_PRODUCTION = "https://connect.moip.com.br";
     public static final String CONNECT_SANDBOX = "https://connect-sandbox.moip.com.br";
     private static String USER_AGENT;
+    private static final String ACCEPT = "application/json;version=";
 
     static {
         try {
@@ -54,7 +55,6 @@ public class Client {
         }
     }
 
-
     private final String endpoint;
     private final Authentication authentication;
     private final Gson gson;
@@ -65,37 +65,45 @@ public class Client {
         this.gson = GsonFactory.gson();
     }
 
+    public <T> T post(final String path, final Class<T> type) {
+        return doRequest("POST", path, null, type, ContentType.APPLICATION_JSON, null);
+    }
+
     public <T> T post(final String path, final Object object, final Class<T> type) {
-        return doRequest("POST", path, object, type, ContentType.APPLICATION_JSON);
+        return doRequest("POST", path, object, type, ContentType.APPLICATION_JSON, null);
     }
 
     public <T> T post(final String path, final Object object, final Class<T> type, ContentType contentType) {
-        return doRequest("POST", path, object, type, contentType);
-    }
-
-    public <T> T post(final String path, final Class<T> type) {
-        return doRequest("POST", path, null, type, ContentType.APPLICATION_JSON);
+        return doRequest("POST", path, object, type, contentType, null);
     }
 
     public <T> T put(final String path, final Object object, final Class<T> type) {
-        return doRequest("PUT", path, object, type, ContentType.APPLICATION_JSON);
+        return doRequest("PUT", path, object, type, ContentType.APPLICATION_JSON, null);
     }
 
     public <T> T get(String path, Class<T> type) {
-        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON);
+        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, null);
+    }
+
+    public <T> T get(String path, Class<T> type, String version) {
+        switch (version) {
+            case "2.1": return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, ACCEPT + version);
+        }
+        return doRequest("GET", path, null, type, ContentType.APPLICATION_JSON, null);
     }
 
     public <T> T delete(String path, Class<T> type) {
-        return doRequest("DELETE", path, null, type, ContentType.APPLICATION_JSON);
+        return doRequest("DELETE", path, null, type, ContentType.APPLICATION_JSON, null);
     }
 
-    private <T> T doRequest(final String method, final String path, final Object object, final Class<T> type, final ContentType contentType) {
+    private <T> T doRequest(final String method, final String path, final Object object, final Class<T> type, final ContentType contentType, final String accept) {
         try {
             URL url = new URL(endpoint + path);
 
             HttpURLConnection conn = (HttpURLConnection) url.openConnection();
             conn.setRequestProperty("User-Agent", USER_AGENT);
             conn.setRequestProperty("Content-type", contentType.getMimeType());
+            if(accept != null) conn.setRequestProperty("Accept", accept);
 
             conn.setRequestMethod(method);
 

--- a/src/main/java/br/com/moip/api/BalancesAPI.java
+++ b/src/main/java/br/com/moip/api/BalancesAPI.java
@@ -1,0 +1,13 @@
+package br.com.moip.api;
+
+import br.com.moip.Client;
+import br.com.moip.resource.Balances;
+
+public class BalancesAPI {
+
+    private final Client client;
+
+    public BalancesAPI(final Client client) { this.client = client; }
+
+    public Balances get() { return client.get("/v2/balances", Balances.class, "2.1"); }
+}

--- a/src/main/java/br/com/moip/resource/Balances.java
+++ b/src/main/java/br/com/moip/resource/Balances.java
@@ -1,0 +1,44 @@
+package br.com.moip.resource;
+
+import java.util.List;
+
+public class Balances {
+
+    private List<Balance> unavailable;
+    private List<Balance> future;
+    private List<Balance> current;
+
+    public Balance getUnavailable() { return unavailable.get(0); }
+
+    public Balance getFuture() { return future.get(0); }
+
+    public Balance getCurrent() { return current.get(0); }
+
+    public class Balance {
+
+        public int amount;
+        public String currency;
+
+        public int getAmount() { return amount; }
+
+        public String getCurrency() { return currency; }
+
+        @Override
+        public String toString() {
+            return new StringBuilder()
+                    .append('{')
+                    .append("amount=").append(amount)
+                    .append(",currency=").append(currency)
+                    .append('}').toString();
+        }
+    }
+
+    @Override
+    public String toString() {
+        return new StringBuilder("Balances{")
+                .append("unavailable=").append(unavailable)
+                .append("future").append(future)
+                .append("current").append(current)
+                .append('}').toString();
+    }
+}

--- a/src/test/java/br/com/moip/api/BalancesAPITest.java
+++ b/src/test/java/br/com/moip/api/BalancesAPITest.java
@@ -1,0 +1,38 @@
+package br.com.moip.api;
+
+import br.com.moip.resource.Balances;
+import com.rodrigosaito.mockwebserver.player.Play;
+import com.rodrigosaito.mockwebserver.player.Player;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class BalancesAPITest {
+
+    @Rule
+    public Player player = new Player();
+
+    private BalancesAPI api;
+
+    @Before
+    public void setUp() {
+        ClientFactory clientFactory = new ClientFactory();
+
+        api = new BalancesAPI(clientFactory.client(player.getURL("").toString()));
+    }
+
+    @Play("balances/get")
+    @Test
+    public void shouldGetBalances() {
+        Balances balances = api.get();
+
+        assertEquals(43902, balances.getUnavailable().getAmount());
+        assertEquals("BRL", balances.getUnavailable().getCurrency());
+        assertEquals(11323, balances.getFuture().getAmount());
+        assertEquals("BRL", balances.getFuture().getCurrency());
+        assertEquals(567094, balances.getCurrent().getAmount());
+        assertEquals("BRL", balances.getCurrent().getCurrency());
+    }
+}

--- a/src/test/resources/plays/balances/get.yaml
+++ b/src/test/resources/plays/balances/get.yaml
@@ -1,0 +1,16 @@
+!play
+interactions:
+-
+  request:
+    uri: /v2/balances
+    headers:
+      "Content-Type": application/json
+      Authorization: Basic MDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDEwMTAxMDE6QUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQkFCQUJBQg==
+      Accept: application/json;version=2.1
+    method: GET
+  response:
+    status: 200
+    headers:
+      "Content-Type": application/json
+    body: |
+      {"unavailable":[{"amount":43902,"currency":"BRL"}],"future":[{"amount":11323,"currency":"BRL"}],"current":[{"amount":567094,"currency":"BRL"}]}


### PR DESCRIPTION
## Story
https://moippagamentos.atlassian.net/browse/DX-92

## Description
Adds `/balances`, to get Moip Account's balances (current, future and unavailable).

## Tasks
- [x] add and configure `/balances` endpoint, on `BalancesAPI.java`;
- [x] add `BalancesAPI` instance, on `API.java`;
- [x] create a balances response resource;
- [x] add `BalancesAPITest` and test it;
- [x] document the new feature.

> **Observations**:
> the `Client.java` was modified to attends the new header _Accept_'s version (now passed as argument).