### PR TITLE
Changing Error visibility

### DIFF
--- a/src/main/java/br/com/moip/models/error/Error.java
+++ b/src/main/java/br/com/moip/models/error/Error.java
@@ -3,7 +3,7 @@
  */
 package br.com.moip.models.error;
 
-class Error {
+public class Error {
 
     private String code;
     private String path;


### PR DESCRIPTION
Changing model class Error visibility modifier to public, so we can get error details when doing exception handling.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moip/moip-sdk-java/17)
<!-- Reviewable:end -->
